### PR TITLE
Box Trait Implementations

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,5 +1,4 @@
 use slab::*;
-
 const CHUNKS: usize = usize::BITS as usize;
 
 fn main() {
@@ -7,8 +6,10 @@ fn main() {
 
     let boxed_values: Vec<_> = (0..(usize::BITS * 32) as u32)
         .into_iter()
-        .map(|x| slab.boxed(x))
+        .map(|x| slab.boxed(x).unwrap())
         .collect();
 
-    println!("{:#?}", &boxed_values)
+    for x in boxed_values.iter() {
+        println!("{}", x);
+    }
 }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,0 +1,14 @@
+use slab::*;
+
+const CHUNKS: usize = usize::BITS as usize;
+
+fn main() {
+    let mut slab = SlabAllocator::<u32, CHUNKS>::new();
+
+    let boxed_values: Vec<_> = (0..(usize::BITS * 32) as u32)
+        .into_iter()
+        .map(|x| slab.boxed(x))
+        .collect();
+
+    println!("{:#?}", &boxed_values)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,16 +36,7 @@ where
     }
 }
 
-impl<T> PartialOrd<T> for Box<T>
-where
-    T: PartialOrd,
-{
-    fn partial_cmp(&self, other: &T) -> Option<core::cmp::Ordering> {
-        self.as_ref().partial_cmp(other)
-    }
-}
-
-impl<T> Eq for Box<T> where T: PartialEq {}
+impl<T> Eq for Box<T> where T: Eq {}
 
 impl<T> core::ops::Deref for Box<T> {
     type Target = T;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,18 @@ pub struct Box<T> {
     inner: *mut T,
 }
 
+impl<T> AsRef<T> for Box<T> {
+    fn as_ref(&self) -> &T {
+        unsafe { self.inner.as_ref().unwrap() }
+    }
+}
+
+impl<T> AsMut<T> for Box<T> {
+    fn as_mut(&mut self) -> &mut T {
+        unsafe { self.inner.as_mut().unwrap() }
+    }
+}
+
 impl<T> PartialEq<T> for Box<T>
 where
     T: PartialEq,
@@ -29,7 +41,7 @@ where
     T: PartialOrd,
 {
     fn partial_cmp(&self, other: &T) -> Option<core::cmp::Ordering> {
-        unsafe { self.inner.as_ref().partial_cmp(&Some(other)) }
+        self.as_ref().partial_cmp(other)
     }
 }
 
@@ -39,15 +51,13 @@ impl<T> core::ops::Deref for Box<T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
-        let inner = unsafe { self.inner.as_ref() }.expect("inner couldn't be borrowed");
-        inner
+        self.as_ref()
     }
 }
 
 impl<T> core::ops::DerefMut for Box<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        let inner = unsafe { self.inner.as_mut() }.expect("inner couldn't be borrowed");
-        inner
+        self.as_mut()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,15 @@ pub struct Box<T> {
     inner: *mut T,
 }
 
+impl<T> core::fmt::Display for Box<T>
+where
+    T: core::fmt::Display,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self.as_ref())
+    }
+}
+
 impl<T> AsRef<T> for Box<T> {
     fn as_ref(&self) -> &T {
         unsafe { self.inner.as_ref().unwrap() }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,12 +8,23 @@ extern crate alloc;
 /// # Warnings
 /// This internal type makes no guarantees of compatibility or even api
 /// similarity. With the `alloc::boxed::Box` implementation.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Box<T> {
     free_mask: usize,
     chunk: *mut Chunk<T>,
     inner: *mut T,
 }
+
+impl<T> PartialEq<T> for Box<T>
+where
+    T: PartialEq,
+{
+    fn eq(&self, other: &T) -> bool {
+        unsafe { self.inner.as_ref() == Some(other) }
+    }
+}
+
+impl<T> Eq for Box<T> where T: PartialEq {}
 
 impl<T> core::ops::Deref for Box<T> {
     type Target = T;
@@ -108,7 +119,7 @@ impl<T> Default for Chunk<T> {
 ///  let mut slab = SlabAllocator::<u8, 1>::new();
 ///  let optional_boxed_five = slab.boxed(5);
 ///
-///  assert_eq!(Some(5), optional_boxed_five.map(|boxed| *boxed));
+///  assert!(optional_boxed_five.unwrap() == 5u8);
 ///
 /// ```
 pub struct SlabAllocator<T, const N: usize> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,7 +129,7 @@ impl<T> Default for Chunk<T> {
 ///  let mut slab = SlabAllocator::<u8, 1>::new();
 ///  let optional_boxed_five = slab.boxed(5);
 ///
-///  assert!(optional_boxed_five.unwrap() == 5u8);
+///  assert!(optional_boxed_five.unwrap().as_ref() == &5u8);
 ///
 /// ```
 pub struct SlabAllocator<T, const N: usize> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ extern crate alloc;
 /// # Warnings
 /// This internal type makes no guarantees of compatibility or even api
 /// similarity. With the `alloc::boxed::Box` implementation.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
 pub struct Box<T> {
     free_mask: usize,
     chunk: *mut Chunk<T>,
@@ -21,6 +21,15 @@ where
 {
     fn eq(&self, other: &T) -> bool {
         unsafe { self.inner.as_ref() == Some(other) }
+    }
+}
+
+impl<T> PartialOrd<T> for Box<T>
+where
+    T: PartialOrd,
+{
+    fn partial_cmp(&self, other: &T) -> Option<core::cmp::Ordering> {
+        unsafe { self.inner.as_ref().partial_cmp(&Some(other)) }
     }
 }
 


### PR DESCRIPTION
# Introduction
This PR implements a few addtional traits for the custom box implementation including

- Display
- PartialEq
- Eq
- PartialOrd
- Deref
- AsRef
- AsMut

Additionally this adds a basic example.

# Linked Issues
Resolves #7 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
